### PR TITLE
Added functionality to ignore ephemeral nodes

### DIFF
--- a/src/main/java/com/github/ksprojects/Configuration.java
+++ b/src/main/java/com/github/ksprojects/Configuration.java
@@ -15,4 +15,6 @@ public interface Configuration {
     int workers();
 
     boolean copyOnly();
+
+    boolean ignoreEphemeralNodes();
 }

--- a/src/main/java/com/github/ksprojects/ZkCopy.java
+++ b/src/main/java/com/github/ksprojects/ZkCopy.java
@@ -11,11 +11,13 @@ public class ZkCopy {
     private static final Logger LOGGER = Logger.getLogger(ZkCopy.class);
     private static final int DEFAULT_THREADS_NUMBER = 10;
     private static final boolean DEFAULT_REMOVE_DEPRECATED_NODES = true;
+    private static final boolean DEFAULT_IGNORE_EPHEMERAL_NODES = false;
     private static final String HELP = "help";
     private static final String SOURCE = "source";
     private static final String TARGET = "target";
     private static final String WORKERS = "workers";
     private static final String COPY_ONLY = "copyOnly";
+    private static final String IGNORE_EPHEMERAL_NODES = "ignoreEphemeralNodes";
 
     public static void main(String[] args) {
         Configuration cfg = parseLegacyConfiguration();
@@ -33,10 +35,11 @@ public class ZkCopy {
         boolean removeDeprecatedNodes = !cfg.copyOnly();
         LOGGER.info("using " + threads + " concurrent workers to copy data");
         LOGGER.info("delete nodes = " + String.valueOf(removeDeprecatedNodes));
+        LOGGER.info("ignore ephemeral nodes = " + String.valueOf(cfg.ignoreEphemeralNodes()));
         Reader reader = new Reader(sourceAddress, threads);
         Node root = reader.read();
         if (root != null) {
-            Writer writer = new Writer(destinationAddress, root, removeDeprecatedNodes);
+            Writer writer = new Writer(destinationAddress, root, removeDeprecatedNodes, cfg.ignoreEphemeralNodes());
             writer.write();
         } else {
             LOGGER.error("FAILED");
@@ -64,11 +67,13 @@ public class ZkCopy {
             String targetValue = getString(line, TARGET);
             int workersValue = getInteger(line, WORKERS, DEFAULT_THREADS_NUMBER);
             boolean copyOnlyValue = getBoolean(line, COPY_ONLY, !DEFAULT_REMOVE_DEPRECATED_NODES);
+            boolean ignoreEphemeralNodes = getBoolean(line, IGNORE_EPHEMERAL_NODES, DEFAULT_IGNORE_EPHEMERAL_NODES);
             return ImmutableConfiguration.builder()
                     .source(sourceValue)
                     .target(targetValue)
                     .workers(workersValue)
                     .copyOnly(copyOnlyValue)
+                    .ignoreEphemeralNodes(ignoreEphemeralNodes)
                     .build();
         } catch (ParseException exp) {
             LOGGER.error("Could not parse options.  Reason: " + exp.getMessage());
@@ -107,12 +112,19 @@ public class ZkCopy {
                 .argName("true|false")
                 .desc("(optional) set this flag if you do not want to remove nodes that are removed on source")
                 .build();
+        Option ignoreEphemeralNodes = Option.builder("i")
+                .longOpt(IGNORE_EPHEMERAL_NODES)
+                .hasArg()
+                .argName("true|false")
+                .desc("(optional) set this flag if you do not want to copy ephemeral ZNodes")
+                .build();
 
         options.addOption(help);
         options.addOption(source);
         options.addOption(target);
         options.addOption(workers);
         options.addOption(copyOnly);
+        options.addOption(ignoreEphemeralNodes);
         return options;
     }
 

--- a/src/main/java/com/github/ksprojects/ZkCopy.java
+++ b/src/main/java/com/github/ksprojects/ZkCopy.java
@@ -11,7 +11,7 @@ public class ZkCopy {
     private static final Logger LOGGER = Logger.getLogger(ZkCopy.class);
     private static final int DEFAULT_THREADS_NUMBER = 10;
     private static final boolean DEFAULT_REMOVE_DEPRECATED_NODES = true;
-    private static final boolean DEFAULT_IGNORE_EPHEMERAL_NODES = false;
+    private static final boolean DEFAULT_IGNORE_EPHEMERAL_NODES = true;
     private static final String HELP = "help";
     private static final String SOURCE = "source";
     private static final String TARGET = "target";

--- a/src/main/java/com/github/ksprojects/zkcopy/Node.java
+++ b/src/main/java/com/github/ksprojects/zkcopy/Node.java
@@ -12,6 +12,7 @@ public class Node
     private final Set<String> childrenNames;
     private String path;
     private byte[] data;
+    private boolean isEphemeral;
     
     public Node(String path) {
         children = new LinkedList<Node>();
@@ -19,6 +20,7 @@ public class Node
         parent = null;
         this.path = path;
         data = null;
+        isEphemeral = false;
     }
     
     public Node(Node parent, String path) {
@@ -79,5 +81,13 @@ public class Node
     
     public byte[] getData() {
         return data;
+    }
+
+    public boolean isEphemeral() {
+        return isEphemeral;
+    }
+
+    public void setEphemeral(boolean ephemeral) {
+        isEphemeral = ephemeral;
     }
 }

--- a/src/main/java/com/github/ksprojects/zkcopy/reader/NodeReader.java
+++ b/src/main/java/com/github/ksprojects/zkcopy/reader/NodeReader.java
@@ -39,10 +39,13 @@ public class NodeReader implements Runnable {
             }
             ReaderThread thread = (ReaderThread) Thread.currentThread();
             ZooKeeper zk = thread.getZooKeeper();
-            Stat stat = null;
+            Stat stat = new Stat();
             String path = znode.getAbsolutePath();
             LOGGER.debug("Reading node " + path);
             byte[] data = zk.getData(path, false, stat);
+            if (stat.getEphemeralOwner() != 0) {
+                znode.setEphemeral(true);
+            }
             znode.setData(data);
             List<String> children = zk.getChildren(path, false);
             for (String child : children) {

--- a/src/main/java/com/github/ksprojects/zkcopy/writer/Writer.java
+++ b/src/main/java/com/github/ksprojects/zkcopy/writer/Writer.java
@@ -1,18 +1,17 @@
 package com.github.ksprojects.zkcopy.writer;
 
-import java.io.IOException;
-import java.util.List;
-
+import com.github.ksprojects.zkcopy.Node;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.ZooDefs.Ids;
+import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
 
-import com.github.ksprojects.zkcopy.Node;
+import java.io.IOException;
+import java.util.List;
 
 public class Writer implements Watcher
 {
@@ -22,12 +21,18 @@ public class Writer implements Watcher
     private String server;
     private String path;
     private ZooKeeper zk;
+    private boolean ignoreEphemeralNodes;
     private boolean removeDeprecated;
+    private long ephemeralIgnored = 0;
+    private long deletedEphemeral = 0;
+    private long nodesUpdated = 0;
+    private long nodesCreated = 0;
     
-    public Writer(String addr, Node znode, boolean removeDeprecatedNodes) {
+    public Writer(String addr, Node znode, boolean removeDeprecatedNodes, boolean ignoreEphemeralNodes) {
         this.addr = addr;
         sourceRoot = znode;
         this.removeDeprecated = removeDeprecatedNodes;
+        this.ignoreEphemeralNodes = ignoreEphemeralNodes;
         parseAddr();        
     }
     
@@ -47,21 +52,17 @@ public class Writer implements Watcher
             logger.info("Writing data...");
             update(dest);
             logger.info("Writing data completed.");
+            logger.info("Wrote " + (nodesCreated + nodesUpdated) + " nodes");
+            logger.info("Created " + nodesCreated + " nodes; Updated " + nodesUpdated + " nodes");
+            logger.info("Ignored " + ephemeralIgnored + " ephemeral nodes");
+            if (deletedEphemeral > 0) {
+                logger.info("Deleted " + deletedEphemeral + " ephemeral nodes");
+            }
+
         }
-        catch(IOException e)
+        catch(IOException|KeeperException|InterruptedException e)
         {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-        catch(KeeperException e)
-        {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-        catch(InterruptedException e)
-        {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            logger.error("Exception caught while writing nodes", e);
         }
     }
     
@@ -82,15 +83,27 @@ public class Writer implements Watcher
 
     private void update(Node node) throws KeeperException, InterruptedException {
         String path = node.getAbsolutePath();
-        
+        if (ignoreEphemeralNodes && node.isEphemeral()) {
+            ephemeralIgnored++;
+            Stat stat = zk.exists(path, false);
+            // only delete ephemeral nodes if they've been copied over persistently before
+            if (stat != null && stat.getEphemeralOwner() == 0) {
+                zk.delete(path, stat.getVersion());
+                deletedEphemeral++;
+            }
+            return;
+        }
+
         // 1. Update or create current node
         Stat stat = zk.exists(path, false);
         if (stat != null) {
             zk.setData(path, node.getData(), -1);
+            nodesUpdated++;
         } else {
             zk.create(path, node.getData(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            nodesCreated++;
         }
-        
+
         // 2. Recursively update or create children
         for(Node child:node.getChildren()) {
             update(child);


### PR DESCRIPTION
This will delete them if they exist (they've been copied over using the current default)
By default it will write them persistently as is the current functionality. 