### PR TITLE
Update Writer.java

### DIFF
--- a/src/main/java/com/github/ksprojects/zkcopy/writer/Writer.java
+++ b/src/main/java/com/github/ksprojects/zkcopy/writer/Writer.java
@@ -114,7 +114,11 @@ public class Writer {
                         if ("zookeeper".equals(child)){
                             continue;
                         }
-                        delete(node.getAbsolutePath() + "/" + child);
+                        if ("/".equals(node.getAbsolutePath())){
+                            delete("/" + child);
+                        }else {
+                            delete(node.getAbsolutePath() + "/" + child);
+                        }
                     }
                 }
             } catch (KeeperException e) {

--- a/src/main/java/com/github/ksprojects/zkcopy/writer/Writer.java
+++ b/src/main/java/com/github/ksprojects/zkcopy/writer/Writer.java
@@ -110,6 +110,10 @@ public class Writer {
                 List<String> destChildren = zk.getChildren(path, false);
                 for (String child : destChildren) {
                     if (!node.getChildrenNamed().contains(child)) {
+                        // skip zookeeper node under the "/"
+                        if ("zookeeper".equals(child)){
+                            continue;
+                        }
                         delete(node.getAbsolutePath() + "/" + child);
                     }
                 }


### PR DESCRIPTION
fix when using args `--source 192.168.127.112:2181,192.168.128.71:2181,192.168.128.72:2181/ --target 192.168.127.81:2181,192.168.127.82:2181,192.168.127.86:2181/`
logs is 
```
2023-09-26 16:06:08,843 [main] INFO  com.github.ksprojects.ZkCopy - using 10 concurrent workers to copy data
2023-09-26 16:06:08,843 [main] INFO  com.github.ksprojects.ZkCopy - delete nodes = true
2023-09-26 16:06:08,843 [main] INFO  com.github.ksprojects.ZkCopy - ignore ephemeral nodes = true
2023-09-26 16:06:08,844 [main] INFO  com.github.ksprojects.zkcopy.reader.Reader - Reading / from 192.168.127.112:2181,192.168.128.71:2181,192.168.128.72:2181
2023-09-26 16:06:09,889 [main] INFO  com.github.ksprojects.zkcopy.reader.Reader - Processing, total=3, processed=3
2023-09-26 16:06:09,890 [main] INFO  com.github.ksprojects.zkcopy.reader.Reader - Completed.
2023-09-26 16:06:09,916 [main] INFO  com.github.ksprojects.zkcopy.writer.Writer - Writing data...
Exception in thread "main" picocli.CommandLine$ExecutionException: Error while calling command (com.github.ksprojects.ZkCopy@58c1c010): java.lang.IllegalArgumentException: Invalid path string "//zookeeper" caused by empty node name specified @1
	at picocli.CommandLine.execute(CommandLine.java:458)
	at picocli.CommandLine.access$300(CommandLine.java:134)
	at picocli.CommandLine$RunLast.handleParseResult(CommandLine.java:538)
	at picocli.CommandLine.parseWithHandlers(CommandLine.java:656)
	at picocli.CommandLine.call(CommandLine.java:883)
	at picocli.CommandLine.call(CommandLine.java:834)
	at com.github.ksprojects.ZkCopy.main(ZkCopy.java:69)
Caused by: java.lang.IllegalArgumentException: Invalid path string "//zookeeper" caused by empty node name specified @1
	at org.apache.zookeeper.common.PathUtils.validatePath(PathUtils.java:99)
	at org.apache.zookeeper.ZooKeeper.getChildren(ZooKeeper.java:1454)
	at org.apache.zookeeper.ZooKeeper.getChildren(ZooKeeper.java:1500)
	at com.github.ksprojects.zkcopy.writer.Writer.delete(Writer.java:160)
	at com.github.ksprojects.zkcopy.writer.Writer.update(Writer.java:117)
	at com.github.ksprojects.zkcopy.writer.Writer.write(Writer.java:65)
	at com.github.ksprojects.ZkCopy.call(ZkCopy.java:86)
	at com.github.ksprojects.ZkCopy.call(ZkCopy.java:14)
	at picocli.CommandLine.execute(CommandLine.java:456)
	... 6 more

Process finished with exit code 1
```
this line show the problem

```
Caused by: java.lang.IllegalArgumentException: Invalid path string "//zookeeper" caused by empty node name specified @1
```



